### PR TITLE
#15 【 UI 】「今日する」「明日する」「今度する」の見出しのコンポーネントを作成

### DIFF
--- a/src/components/Title/SomeTimeTitle.tsx
+++ b/src/components/Title/SomeTimeTitle.tsx
@@ -1,0 +1,19 @@
+import type { VFC } from "react";
+
+export const SomeTimeTitle: VFC = () => {
+  return (
+    //見出しコンポーネント(今度する)を作成
+    <div className="m-4">
+      <div>
+        <h1
+          className="
+                font-mono
+                text-22px
+                text-tertiary-yellow"
+        >
+          今度する
+        </h1>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Title/TodayTitle.tsx
+++ b/src/components/Title/TodayTitle.tsx
@@ -1,0 +1,19 @@
+import type { VFC } from "react";
+
+export const TodayTitle: VFC = () => {
+  return (
+    //見出しコンポーネント(今日する)を作成
+    <div className="m-4">
+      <div>
+        <h1
+          className="
+                font-mono
+                text-22px
+                text-primary-rose"
+        >
+          今日する
+        </h1>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Title/TomorrowTitle.tsx
+++ b/src/components/Title/TomorrowTitle.tsx
@@ -1,0 +1,19 @@
+import type { VFC } from "react";
+
+export const TomorrowTitle: VFC = () => {
+  return (
+    //見出しコンポーネント(明日する)を作成
+    <div className="m-4">
+      <div>
+        <h1
+          className="
+                font-mono
+                text-22px
+                text-secondary-orange"
+        >
+          明日する
+        </h1>
+      </div>
+    </div>
+  );
+};

--- a/src/components/btn/BtnArea.tsx
+++ b/src/components/btn/BtnArea.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode,VFC } from "react";
+import type { ReactNode, VFC } from "react";
 
 export const BtnArea: VFC<{ children: ReactNode }> = (props) => {
   return <div className="flex">{props.children}</div>;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,9 @@ import { SomeTimeBtn } from "src/components/btn/SomeTimeBtn";
 import { TodayBtn } from "src/components/btn/TodayBtn";
 import { TomorrowBtn } from "src/components/btn/TomorrowBtn";
 import { Layout } from "src/components/layout";
+import { SomeTimeTitle } from "src/components/Title/SomeTimeTitle";
+import { TodayTitle } from "src/components/Title/TodayTitle";
+import { TomorrowTitle } from "src/components/Title/TomorrowTitle";
 
 const Home: NextPage = () => {
   const handleClick = () => {
@@ -23,6 +26,9 @@ const Home: NextPage = () => {
         <TomorrowBtn />
         <SomeTimeBtn />
       </BtnArea>
+      <TodayTitle />
+      <TomorrowTitle />
+      <SomeTimeTitle />
       <button onClick={handleClick}>Button</button>
     </Layout>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,21 @@
 module.exports = {
   content: ["./pages/**/*.{js,ts,jsx,tsx}", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
+    //FontSize22px,Lineheight26pxを追加するために設定しました
+    fontSize: {
+      xs: ".75rem",
+      sm: ".875rem",
+      base: "1rem",
+      lg: "1.125rem",
+      xl: "1.25rem",
+      "2xl": "1.5rem",
+      "3xl": "1.875rem",
+      "4xl": "2.25rem",
+      "5xl": "3rem",
+      "6xl": "4rem",
+      "7xl": "5rem",
+      "22px": ["22px", "26px"],
+    },
     extend: {
       colors: {
         primary: {


### PR DESCRIPTION
## やったこと

・タイトルコンポーネントの作成
・TailwindcssにFontSize22px,Lineheight26pxを追加

## やっていないこと
・Todoコンポーネントの作成
・TodoItemコンポーネントの作成

<img width="1434" alt="スクリーンショット 2022-02-27 22 15 17 1" src="https://user-images.githubusercontent.com/87214030/155883970-609a6efc-b69f-4116-81ce-6baeb7eb5482.png">
