### PR TITLE
#17 Layoutコンポーネントのスタイリングを行う。

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -4,10 +4,12 @@ import { Header } from "src/components/header";
 
 export const Layout: VFC<{ children: ReactNode }> = (props) => {
   return (
-    <>
+    <div className="flex flex-col min-h-screen">
       <Header />
-      <main>{props.children}</main>
-      <Footer />
-    </>
+      <main className="flex flex-1 items-stretch bg-blue-100">{props.children}</main>
+      <div className="sm:hidden">
+        <Footer />
+      </div>
+    </div>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,6 @@ import { TodayTitle } from "src/components/Title/TodayTitle";
 import { TomorrowTitle } from "src/components/Title/TomorrowTitle";
 
 const Home: NextPage = () => {
-
   return (
     <Layout>
       <Head>
@@ -40,7 +39,6 @@ const Home: NextPage = () => {
       <TodayTitle />
       <TomorrowTitle />
       <SomeTimeTitle />
-      <button onClick={handleClick}>Button</button>
       <NewTask />
     </Layout>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,16 +1,6 @@
 import type { NextPage } from "next";
 import Head from "next/head";
-import { BtnArea } from "src/components/btn/BtnArea";
-import { RadioBtn } from "src/components/btn/RadioBtn/RadioBtn";
-import { RadioBtnGroup } from "src/components/btn/RadioBtn/RadioBtnGroup";
-import { SomeTimeBtn } from "src/components/btn/SomeTimeBtn";
-import { TodayBtn } from "src/components/btn/TodayBtn";
-import { TomorrowBtn } from "src/components/btn/TomorrowBtn";
 import { Layout } from "src/components/layout";
-import { NewTask } from "src/components/NewTask";
-import { SomeTimeTitle } from "src/components/Title/SomeTimeTitle";
-import { TodayTitle } from "src/components/Title/TodayTitle";
-import { TomorrowTitle } from "src/components/Title/TomorrowTitle";
 
 const Home: NextPage = () => {
   return (
@@ -19,27 +9,11 @@ const Home: NextPage = () => {
         <title>Home</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <h2 className="p-2 bg-red-400">Home</h2>
-      <BtnArea>
-        <TodayBtn />
-        <TomorrowBtn />
-        <SomeTimeBtn />
-      </BtnArea>
-      <RadioBtnGroup>
-        <RadioBtn variant="rose" value="task1">
-          ここにタスクが入ります
-        </RadioBtn>
-        <RadioBtn variant="orange" value="task2">
-          ここにタスクが入ります
-        </RadioBtn>
-        <RadioBtn variant="yellow" value="task3">
-          ここにタスクが入ります
-        </RadioBtn>
-      </RadioBtnGroup>
-      <TodayTitle />
-      <TomorrowTitle />
-      <SomeTimeTitle />
-      <NewTask />
+      <div className="flex flex-col items-start py-6 px-4 space-y-4 w-full min-h-full bg-green-100 sm:flex-row sm:justify-between sm:py-16 sm:px-[81px] sm:space-y-0 sm:space-x-4">
+        <div className="w-full h-[100px] bg-red-100 sm:flex-1">今日する</div>
+        <div className="w-full h-[200px] bg-orange-100 sm:flex-1">明日する</div>
+        <div className="w-full h-[300px] bg-yellow-100 sm:flex-1">今度する</div>
+      </div>
     </Layout>
   );
 };


### PR DESCRIPTION
## Issue URL

#17 

## やったこと

- header, main, footerのレイアウト(PC, アプリ)を行なった。
- mainコンポーネント内にサンプルで表示していたコンポーネントを削除し、仮のTodoコンポーネントをmainコンポーネントに配置した。
- mainコンポーネント、仮Todoコンポーネントの配置がわかるように仮の背景色をつけた。

## やってないこと
- Todoコンポーネントが出来次第、置き換えます。また、背景色もwhiteに戻します。

## 画像 URL
- アプリ
![#17_apli](https://user-images.githubusercontent.com/63755760/156501052-fbbcea16-b22f-4384-98d3-742faee86eda.png)

- PC
![#17_desktop](https://user-images.githubusercontent.com/63755760/156501091-c255ead2-3701-4c6d-8764-b4022be1c0f1.png)

