### PR TITLE
#68 完了時のボタンの色を日付別カラーに合わせる

### DIFF
--- a/src/components/Todo/SomeTimeTodo.tsx
+++ b/src/components/Todo/SomeTimeTodo.tsx
@@ -22,6 +22,7 @@ export const SomeTimeTodo = () => {
                   setTaskList={setSomeTimeTask}
                   id={item.id}
                   checked={item.checked}
+                  tailChecked="checked:bg-tertiary-yellow"
                 />
                 <div className="flex pb-6 m-auto space-x-4">
                   <CopyBtn
@@ -42,7 +43,7 @@ export const SomeTimeTodo = () => {
           })
         : null}
       <RadioBtnGroup>
-        <TodoItem task={""} setTaskList={setSomeTimeTask} id={""} checked={false} />
+        <TodoItem task={""} setTaskList={setSomeTimeTask} id={""} checked={false} tailChecked={""} />
       </RadioBtnGroup>
     </div>
   );

--- a/src/components/Todo/TodayTodo.tsx
+++ b/src/components/Todo/TodayTodo.tsx
@@ -22,6 +22,7 @@ export const TodayTodo = () => {
                   setTaskList={setTodayTask}
                   id={item.id}
                   checked={item.checked}
+                  tailChecked="checked:bg-primary-rose"
                 />
                 <div className="flex pb-6 m-auto space-x-4">
                   <CopyBtn
@@ -42,7 +43,7 @@ export const TodayTodo = () => {
           })
         : null}
       <RadioBtnGroup>
-        <TodoItem task={""} setTaskList={setTodayTask} id={""} checked={false} />
+        <TodoItem task={""} setTaskList={setTodayTask} id={""} checked={false} tailChecked={""} />
       </RadioBtnGroup>
     </div>
   );

--- a/src/components/Todo/TodoItem/TodoItem.tsx
+++ b/src/components/Todo/TodoItem/TodoItem.tsx
@@ -14,6 +14,7 @@ type TodoItemProps = {
   setTaskList: Dispatch<SetStateAction<Task[]>>;
   readonly id: string;
   checked: boolean;
+  tailChecked: string;
 };
 
 export const TodoItem: VFC<TodoItemProps> = (props) => {
@@ -111,8 +112,8 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
             //タスクの完了/未完了を操作(checkedを使用)
             checked={props.checked} //これが無いと、taskをクリックした際、ボタンが赤くならない
             onChange={handleOnCheck}
-            //ボタンの赤色は、擬似クラス（checked:)で制御。textarea同様、三項演算でも設定可能
-            className="absolute w-4 h-4 checked:bg-red-500 rounded-full border-baseGray-200 appearance-none cursor-pointer"
+            //時期別コンポーネントで指定された色がpropsとして渡され表示
+            className={`absolute w-4 h-4 rounded-full border-baseGray-200 appearance-none cursor-pointer ${props.tailChecked}`}
           />
         </div>
       ) : (

--- a/src/components/Todo/TomorrowTodo.tsx
+++ b/src/components/Todo/TomorrowTodo.tsx
@@ -21,6 +21,7 @@ export const TomorrowTodo = () => {
                   setTaskList={setTomorrowTask}
                   id={item.id}
                   checked={item.checked}
+                  tailChecked="checked:bg-secondary-orange"
                 />
                 <div className="flex pb-6 m-auto space-x-4">
                   <CopyBtn
@@ -41,7 +42,7 @@ export const TomorrowTodo = () => {
           })
         : null}
       <RadioBtnGroup>
-        <TodoItem task={""} setTaskList={setTomorrowTask} id={""} checked={false} />
+        <TodoItem task={""} setTaskList={setTomorrowTask} id={""} checked={false} tailChecked={""} />
       </RadioBtnGroup>
     </div>
   );


### PR DESCRIPTION
## 変更の概要

完了時のボタンの色を日付別タイトル（「今日する」「明日する」「今度する」）の文字色と合わせる

## なぜこの変更をするのか
*FIGMAの仕様に合わせるため

## やったこと
*現在Tailwindの色クラスには、色クラス名checked:bg-red-500が記載されているが、これを変数tailCheckedに変更した。
*日付別コンポーネントのpropsとして色の値（クラス）を明記し、それを TodoItemコンポーネントに渡して表示した。

## 変更内容
![スクリーンショット 2022-04-06 16 14 51](https://user-images.githubusercontent.com/74279452/161917197-fbfd0d9f-b63e-4adc-84f6-ad198404aa56.png)

## 課題他
*特にありません。