### PR TITLE
#54 テキストエリアを行数に応じて自動で広げる

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "@mantine/next": "4.0.7",
     "next": "12.0.10",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "react-textarea-autosize": "8.3.3"
   },
   "devDependencies": {
     "@testing-library/react": "12.1.3",

--- a/src/components/Todo/SomeTimeTodo.tsx
+++ b/src/components/Todo/SomeTimeTodo.tsx
@@ -24,12 +24,13 @@ export const SomeTimeTodo = () => {
                   checked={item.checked}
                   tailChecked="checked:bg-tertiary-yellow"
                 />
-                <div className="flex pb-6 m-auto space-x-4">
+                <div className="flex items-start pb-6 space-x-4">
                   <CopyBtn
                     id={item.id}
                     task={item.task ? item.task : ""}
                     setTaskList={setSomeTimeTask}
                     taskList={someTimeTask}
+                    checked={item.checked}
                   />
                   <TrashBtn
                     id={item.id}

--- a/src/components/Todo/TodayTodo.tsx
+++ b/src/components/Todo/TodayTodo.tsx
@@ -24,12 +24,13 @@ export const TodayTodo = () => {
                   checked={item.checked}
                   tailChecked="checked:bg-primary-rose"
                 />
-                <div className="flex pb-6 m-auto space-x-4">
+                <div className="flex items-start pb-6 space-x-4">
                   <CopyBtn
                     id={item.id}
                     task={item.task ? item.task : ""}
                     setTaskList={setTodayTask}
                     taskList={todayTask}
+                    checked={item.checked}
                   />
                   <TrashBtn
                     id={item.id}

--- a/src/components/Todo/TodoItem/TodoItem.tsx
+++ b/src/components/Todo/TodoItem/TodoItem.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent, Dispatch, KeyboardEventHandler, SetStateAction, VFC } from "react";
 import { useCallback } from "react";
 import { useEffect, useState } from "react";
+import TextareaAutosize from "react-textarea-autosize";
 import { PlusBtn } from "src/components/btn/PlusBtn";
 
 export type Task = {
@@ -22,6 +23,7 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
   const [isFocused, setIsFocused] = useState<boolean>(false);
   //全角文字変換前の入力値を保存する
   const [isComposing, setIsComposing] = useState(false);
+  // const [textAreaHeight, setTextAreaHeight] = useState()
 
   useEffect(() => {
     setTask(props.task);
@@ -36,11 +38,6 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
     const task = e.target.value.replace("\n", "");
     setTask(task);
   };
-  //textareaの高さ自動（WIP）
-  // const calcTextAreaHeight = (task: string) => {
-  //     const rowsNum: number = task.split('\n').length;
-  //     return rowsNum
-  //   }
 
   //最大200文字まで書き込み、それ以上は入力文字数制限
   const handleCountChange = (e: any) => {
@@ -119,8 +116,7 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
       ) : (
         <PlusBtn />
       )}
-      <textarea
-        // rows={calcTextAreaHeight(task)}
+      <TextareaAutosize
         value={task}
         maxLength={200}
         onKeyUp={handleCountChange}

--- a/src/components/Todo/TomorrowTodo.tsx
+++ b/src/components/Todo/TomorrowTodo.tsx
@@ -23,12 +23,13 @@ export const TomorrowTodo = () => {
                   checked={item.checked}
                   tailChecked="checked:bg-secondary-orange"
                 />
-                <div className="flex pb-6 m-auto space-x-4">
+                <div className="flex items-start pb-6 space-x-4">
                   <CopyBtn
                     id={item.id}
                     task={item.task ? item.task : ""}
                     setTaskList={setTomorrowTask}
                     taskList={tomorrowTask}
+                    checked={item.checked}
                   />
                   <TrashBtn
                     id={item.id}

--- a/src/components/btn/CopyBtn.tsx
+++ b/src/components/btn/CopyBtn.tsx
@@ -8,6 +8,7 @@ type TodoItemProps = {
   task: string;
   setTaskList: Dispatch<SetStateAction<Task[]>>;
   taskList: Task[];
+  checked: boolean;
 };
 
 export const CopyBtn: VFC<TodoItemProps> = (props) => {
@@ -27,7 +28,7 @@ export const CopyBtn: VFC<TodoItemProps> = (props) => {
         return item.id === props.id;
       });
       const beforeIndexList = prev.slice(0, index);
-      const middleList = filteredItem.concat({ id: newId, task: props.task });
+      const middleList = filteredItem.concat({ id: newId, task: props.task, checked: props.checked });
       return beforeIndexList.concat(middleList, prev.slice(index + 1, prev.length));
     });
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4271,7 +4271,7 @@ react-property@2.0.0:
   resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
   integrity sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==
 
-react-textarea-autosize@^8.3.2:
+react-textarea-autosize@^8.3.2, react-textarea-autosize@^8.3.3:
   version "8.3.3"
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz#f70913945369da453fd554c168f6baacd1fa04d8"
   integrity sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==


### PR DESCRIPTION
# IssueURL

#54 

# 画像

[![Image from Gyazo](https://i.gyazo.com/75869534270bbf0aa9765d6ae590bf5d.png)](https://gyazo.com/75869534270bbf0aa9765d6ae590bf5d)

# レビュー後
[![Image from Gyazo](https://i.gyazo.com/1ae18c726d530573ad5e494ce967f8a3.gif)](https://gyazo.com/1ae18c726d530573ad5e494ce967f8a3)

# やったこと
- react-textarea-autosizeライブラリの導入
- copyとTrashボタンの位置修正

**checkedプロパティの実装**
- そのままではTSに怒られるため、copyボタンに、未実装だったcheckedプロパティを実装。
- 上記の続きでtodayTask, tomorrowTask, someTimeTaskにもcheckedプロパティを実装した。

