### PR TITLE
textareaのライブラリを導入した後に発生したyarnlockの問題を解決する

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4271,7 +4271,7 @@ react-property@2.0.0:
   resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
   integrity sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==
 
-react-textarea-autosize@^8.3.2, react-textarea-autosize@^8.3.3:
+react-textarea-autosize@8.3.3, react-textarea-autosize@^8.3.2:
   version "8.3.3"
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz#f70913945369da453fd554c168f6baacd1fa04d8"
   integrity sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==


### PR DESCRIPTION
# やったこと

やるべき流れ
```
1. yarn add react-textarea-autosize
2. package.jsonで"^8.3.3"の^を削除 　(※ここまではtextareaのライブラリ導入時に済んでいる。)
3. package.jsonを修正したので、再度yarnを行う。
4. yarn.lockが更新されるので、commit & push
```
のうち3、4を行った。

# 自信のないところ
yarn lock修正後に`react-textarea-autosize@8.3.3, react-textarea-autosize@^8.3.2:`
と記載があり、まだ^が記載されている。