### PR TITLE
プラスボタンをクリックすると、入力カーソルが表示されるようにする

### DIFF
--- a/src/components/Todo/SomeTimeTodo.tsx
+++ b/src/components/Todo/SomeTimeTodo.tsx
@@ -48,7 +48,14 @@ export const SomeTimeTodo = () => {
           })
         : null}
       <RadioBtnGroup>
-        <TodoItem task={""} setTaskList={setSomeTimeTask} id={""} checked={false} tailChecked={""} registered={false} />
+        <TodoItem
+          task={""}
+          setTaskList={setSomeTimeTask}
+          id={"sometome"}
+          checked={false}
+          tailChecked={""}
+          registered={false}
+        />
       </RadioBtnGroup>
     </div>
   );

--- a/src/components/Todo/TodayTodo.tsx
+++ b/src/components/Todo/TodayTodo.tsx
@@ -48,7 +48,14 @@ export const TodayTodo = () => {
           })
         : null}
       <RadioBtnGroup>
-        <TodoItem task={""} setTaskList={setTodayTask} id={""} checked={false} tailChecked={""} registered={false} />
+        <TodoItem
+          task={""}
+          setTaskList={setTodayTask}
+          id={"today"}
+          checked={false}
+          tailChecked={""}
+          registered={false}
+        />
       </RadioBtnGroup>
     </div>
   );

--- a/src/components/Todo/TodoItem/TodoItem.tsx
+++ b/src/components/Todo/TodoItem/TodoItem.tsx
@@ -119,6 +119,11 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
     setIsFocused(false);
   };
 
+  //「タスクを追加する」でクリック（focus）した場合
+  const handleOnButtonFocus = () => {
+    setIsFocused(true);
+  };
+
   return (
     <div className="flex flex-row pb-1 pl-1">
       {isFocused || task || props.registered ? (
@@ -130,10 +135,11 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
             onChange={handleOnCheck}
             //時期別コンポーネントで指定された色がpropsとして渡され表示
             className={`absolute w-4 h-4 rounded-full border-baseGray-200 appearance-none cursor-pointer ${props.tailChecked}`}
+            onClick={handleOnBlur}
           />
         </div>
       ) : (
-        <PlusBtn />
+        <PlusBtn onClick={handleOnButtonFocus} />
       )}
       <TextareaAutosize
         value={task}
@@ -143,7 +149,7 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
         onKeyDown={handleOnKeyDown}
         //イベントハンドラー（タスクの完了/未完了を操作）
         placeholder={isFocused || props.registered ? "" : "タスクを追加する"}
-        onClick={handleOnCheck}
+        // onClick={handleOnCheck}
         //全角文字変換前の入力値を監視する
         onCompositionStart={handleStartComposition}
         onCompositionEnd={handleEndComposition}

--- a/src/components/Todo/TodoItem/TodoItem.tsx
+++ b/src/components/Todo/TodoItem/TodoItem.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, Dispatch, KeyboardEventHandler, SetStateAction, VFC } from "react";
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import { useEffect, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { PlusBtn } from "src/components/btn/PlusBtn";
@@ -120,49 +120,54 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
   };
 
   //「タスクを追加する」でクリック（focus）した場合
-  // const handleOnButtonFocus = () => {
-  //   setIsFocused(true);
-  // };
+  const handleOnButtonFocus = () => {
+    setIsFocused(true);
+  };
 
   //フォーカス設定（＋ボタンを押した際、入力欄でカーソルが点滅するようにする）
-  const inputEl = useRef(null);
+  // const inputEl = useRef(null);
 
-  const handleOnClick = () => {
-    setIsFocused(true);
-    inputEl.current.focus();
-  };
+  // const handleOnClick = () => {
+  //   setIsFocused(true);
+  //   inputEl.current.focus();
+  // };
 
   return (
     <div className="flex flex-row pb-1 pl-1">
-      {isFocused || task || props.registered ? (
-        <div className="flex relative justify-center items-center w-6 h-6 rounded-full border-2 border-baseGray-200 border-solid">
-          <input
-            type="checkbox"
-            //タスクの完了/未完了を操作(checkedを使用)
-            checked={props.checked} //これが無いと、taskをクリックした際、ボタンが赤くならない
-            onChange={handleOnCheck}
-            //時期別コンポーネントで指定された色がpropsとして渡され表示
-            className={`absolute w-4 h-4 rounded-full border-baseGray-200 appearance-none cursor-pointer ${props.tailChecked}`}
-            onClick={handleOnBlur}
-          />
-        </div>
-      ) : (
-        <PlusBtn onClick={handleOnClick} />
-      )}
-      <TextareaAutosize
-        ref={inputEl} //フォーカス設定
-        value={task}
-        maxLength={200}
-        onKeyUp={handleCountChange}
-        onChange={handleChangeTask}
-        onKeyDown={handleOnKeyDown}
-        //イベントハンドラー（タスクの完了/未完了を操作）
-        placeholder={isFocused || props.registered ? "" : "タスクを追加する"}
-        // onClick={handleOnCheck}
-        //全角文字変換前の入力値を監視する
-        onCompositionStart={handleStartComposition}
-        onCompositionEnd={handleEndComposition}
-        className={`
+      <label htmlFor={props.id}>
+        {isFocused || task || props.registered ? (
+          <div className="flex relative justify-center items-center w-6 h-6 rounded-full border-2 border-baseGray-200 border-solid">
+            <input
+              type="checkbox"
+              //タスクの完了/未完了を操作(checkedを使用)
+              checked={props.checked} //これが無いと、taskをクリックした際、ボタンが赤くならない
+              onChange={handleOnCheck}
+              //時期別コンポーネントで指定された色がpropsとして渡され表示
+              className={`absolute w-4 h-4 rounded-full border-baseGray-200 appearance-none cursor-pointer ${props.tailChecked}`}
+              onClick={handleOnBlur}
+            />
+          </div>
+        ) : (
+          <PlusBtn onClick={handleOnButtonFocus} />
+          // <PlusBtn onClick={handleOnClick} />
+        )}
+      </label>
+      <label htmlFor={props.id}>
+        <TextareaAutosize
+          id={props.id}
+          // ref={inputEl} //フォーカス設定
+          value={task}
+          maxLength={200}
+          onKeyUp={handleCountChange}
+          onChange={handleChangeTask}
+          onKeyDown={handleOnKeyDown}
+          //イベントハンドラー（タスクの完了/未完了を操作）
+          placeholder={isFocused || props.registered ? "" : "タスクを追加する"}
+          // onClick={handleOnCheck}
+          //全角文字変換前の入力値を監視する
+          onCompositionStart={handleStartComposition}
+          onCompositionEnd={handleEndComposition}
+          className={`
                   overflow-hidden
                   ml-3
                   focus:outline-none
@@ -173,9 +178,10 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
                     props.checked === true ? "line-through text-baseGray-200" : ""
                   }
                   `}
-        onFocus={handleOnFocus}
-        onBlur={handleOnBlur}
-      />
+          onFocus={handleOnFocus}
+          onBlur={handleOnBlur}
+        />
+      </label>
     </div>
   );
 };

--- a/src/components/Todo/TodoItem/TodoItem.tsx
+++ b/src/components/Todo/TodoItem/TodoItem.tsx
@@ -124,14 +124,6 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
     setIsFocused(true);
   };
 
-  //フォーカス設定（＋ボタンを押した際、入力欄でカーソルが点滅するようにする）
-  // const inputEl = useRef(null);
-
-  // const handleOnClick = () => {
-  //   setIsFocused(true);
-  //   inputEl.current.focus();
-  // };
-
   return (
     <div className="flex flex-row pb-1 pl-1">
       <label htmlFor={props.id}>
@@ -149,25 +141,21 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
           </div>
         ) : (
           <PlusBtn onClick={handleOnButtonFocus} />
-          // <PlusBtn onClick={handleOnClick} />
         )}
       </label>
-      <label htmlFor={props.id}>
-        <TextareaAutosize
-          id={props.id}
-          // ref={inputEl} //フォーカス設定
-          value={task}
-          maxLength={200}
-          onKeyUp={handleCountChange}
-          onChange={handleChangeTask}
-          onKeyDown={handleOnKeyDown}
-          //イベントハンドラー（タスクの完了/未完了を操作）
-          placeholder={isFocused || props.registered ? "" : "タスクを追加する"}
-          // onClick={handleOnCheck}
-          //全角文字変換前の入力値を監視する
-          onCompositionStart={handleStartComposition}
-          onCompositionEnd={handleEndComposition}
-          className={`
+      <TextareaAutosize
+        id={props.id}
+        value={task}
+        maxLength={200}
+        onKeyUp={handleCountChange}
+        onChange={handleChangeTask}
+        onKeyDown={handleOnKeyDown}
+        //イベントハンドラー（タスクの完了/未完了を操作）
+        placeholder={isFocused || props.registered ? "" : "タスクを追加する"}
+        //全角文字変換前の入力値を監視する
+        onCompositionStart={handleStartComposition}
+        onCompositionEnd={handleEndComposition}
+        className={`
                   overflow-hidden
                   ml-3
                   focus:outline-none
@@ -178,10 +166,9 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
                     props.checked === true ? "line-through text-baseGray-200" : ""
                   }
                   `}
-          onFocus={handleOnFocus}
-          onBlur={handleOnBlur}
-        />
-      </label>
+        onFocus={handleOnFocus}
+        onBlur={handleOnBlur}
+      />
     </div>
   );
 };

--- a/src/components/Todo/TodoItem/TodoItem.tsx
+++ b/src/components/Todo/TodoItem/TodoItem.tsx
@@ -136,7 +136,6 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
               onChange={handleOnCheck}
               //時期別コンポーネントで指定された色がpropsとして渡され表示
               className={`absolute w-4 h-4 rounded-full border-baseGray-200 appearance-none cursor-pointer ${props.tailChecked}`}
-              onClick={handleOnBlur}
             />
           </div>
         ) : (

--- a/src/components/Todo/TodoItem/TodoItem.tsx
+++ b/src/components/Todo/TodoItem/TodoItem.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, Dispatch, KeyboardEventHandler, SetStateAction, VFC } from "react";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useEffect, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { PlusBtn } from "src/components/btn/PlusBtn";
@@ -120,8 +120,16 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
   };
 
   //「タスクを追加する」でクリック（focus）した場合
-  const handleOnButtonFocus = () => {
+  // const handleOnButtonFocus = () => {
+  //   setIsFocused(true);
+  // };
+
+  //フォーカス設定（＋ボタンを押した際、入力欄でカーソルが点滅するようにする）
+  const inputEl = useRef(null);
+
+  const handleOnClick = () => {
     setIsFocused(true);
+    inputEl.current.focus();
   };
 
   return (
@@ -139,9 +147,10 @@ export const TodoItem: VFC<TodoItemProps> = (props) => {
           />
         </div>
       ) : (
-        <PlusBtn onClick={handleOnButtonFocus} />
+        <PlusBtn onClick={handleOnClick} />
       )}
       <TextareaAutosize
+        ref={inputEl} //フォーカス設定
         value={task}
         maxLength={200}
         onKeyUp={handleCountChange}

--- a/src/components/Todo/TomorrowTodo.tsx
+++ b/src/components/Todo/TomorrowTodo.tsx
@@ -48,7 +48,14 @@ export const TomorrowTodo = () => {
           })
         : null}
       <RadioBtnGroup>
-        <TodoItem task={""} setTaskList={setTomorrowTask} id={""} checked={false} tailChecked={""} registered={false} />
+        <TodoItem
+          task={""}
+          setTaskList={setTomorrowTask}
+          id={"tomorrow"}
+          checked={false}
+          tailChecked={""}
+          registered={false}
+        />
       </RadioBtnGroup>
     </div>
   );

--- a/src/components/btn/PlusBtn.tsx
+++ b/src/components/btn/PlusBtn.tsx
@@ -8,11 +8,11 @@ type PlusBtnProps = {
 export const PlusBtn: VFC<PlusBtnProps> = (props) => {
   return (
     <div>
-      <button className="relative" onClick={props.onClick}>
+      <div className="relative" onChange={props.onClick}>
         <div className="box-border flex justify-center items-center w-[24px] h-[24px] bg-[#C2C6D2] rounded-full border-solid cursor-pointer">
           <Image alt="plus" src="/plus_icon.png" width="11px" height="11px" />
         </div>
-      </button>
+      </div>
     </div>
   );
 };

--- a/src/components/btn/PlusBtn.tsx
+++ b/src/components/btn/PlusBtn.tsx
@@ -8,10 +8,13 @@ type PlusBtnProps = {
 export const PlusBtn: VFC<PlusBtnProps> = (props) => {
   return (
     <div>
-      <div className="relative" onChange={props.onClick}>
-        <div className="box-border flex justify-center items-center w-[24px] h-[24px] bg-[#C2C6D2] rounded-full border-solid cursor-pointer">
+      <div className="relative">
+        <button
+          className="box-border flex justify-center items-center w-[24px] h-[24px] bg-[#C2C6D2] rounded-full border-solid cursor-pointer"
+          onClick={props.onClick}
+        >
           <Image alt="plus" src="/plus_icon.png" width="11px" height="11px" />
-        </div>
+        </button>
       </div>
     </div>
   );

--- a/src/components/btn/PlusBtn.tsx
+++ b/src/components/btn/PlusBtn.tsx
@@ -1,14 +1,18 @@
 import Image from "next/image";
 import type { VFC } from "react";
 
-export const PlusBtn: VFC = () => {
+type PlusBtnProps = {
+  onClick: () => void;
+};
+
+export const PlusBtn: VFC<PlusBtnProps> = (props) => {
   return (
     <div>
-      <div className="relative">
+      <button className="relative" onClick={props.onClick}>
         <div className="box-border flex justify-center items-center w-[24px] h-[24px] bg-[#C2C6D2] rounded-full border-solid cursor-pointer">
           <Image alt="plus" src="/plus_icon.png" width="11px" height="11px" />
         </div>
-      </div>
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
##変更の概要

登録前の入力欄のViewを、ボタンでも変えることができるようにしよう。

##画像
![スクリーンショット 2022-04-12 21 56 52](https://user-images.githubusercontent.com/74279452/162967532-18285125-f90f-4a53-b33c-285978e44d16.png)


##変更内容：

#したこと

- プラスボタンをクリックすると、「タスクを追加する」が消え、◯ボタンと点滅カーソルに切り替わるようにした。
- その後、同じボタンをもう一度、クリックすると、元に戻るようにした。

##その他したこと
・issueには記載していなかったが、完了時にタスクに横線を引くイベントは、ボタンクリックのみにした。（タスクをクリックしても、横線が引かれないようにした。）
・けんいちさんが挙動が変と指摘されていた件で、シマブーさんにも確認済み。

